### PR TITLE
Refactored bundler completely

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
     name = 'tangram_bundler',
     url = 'https://github.com/tangrams/bundler',
-    version = 0.6,
+    version = 0.7,
     install_requires = [
         'PyYAML == 3.12'
     ],

--- a/tangram_bundler/__init__.py
+++ b/tangram_bundler/__init__.py
@@ -324,6 +324,15 @@ def bundler(filename, unifiedYaml, exportAsJson):
             zipf.write(file)
     zipf.close()
 
+    # delete unified file post bundling
+    if unifiedYaml:
+        if exportAsJson:
+            unifiedBundledSceneJsonPath = os.path.abspath(urljoin(absFilename, "./unifiedBundledScene.json"))
+            os.remove(unifiedBundledSceneJsonPath)
+        else:
+            unifiedBundledSceneYamlPath = os.path.abspath(urljoin(absFilename, "./unifiedBundledScene.yaml"))
+            os.remove(unifiedBundledSceneYamlPath)
+
 def main():
 
     parser = argparse.ArgumentParser()

--- a/tangram_bundler/__init__.py
+++ b/tangram_bundler/__init__.py
@@ -27,13 +27,14 @@ def fetchDependencies(fileList, rootNode, basePath):
         fontsNode = rootNode['fonts']
         for font in fontsNode:
             fontNode = fontsNode[font]
-            for prop in fontNode:
-                # initial Tangram font support
-                if 'url' in prop:
-                    fileList.append(os.path.relpath(prop['url'], basePath))
-                # newer Tangram font support
-                if 'weight' in prop and type(prop['weight']) is str:
-                    fileList.append(os.path.relpath(prop['weight'], basePath))
+            # single face object
+            if 'url' in fontNode and type(fontNode['url']) is str:
+                fileList.append(os.path.relpath(fontNode['url'], basePath))
+            else:
+                # multiple font face objects
+                for face in fontNode:
+                    if 'url' in face:
+                        fileList.append(os.path.relpath(face['url'], basePath))
 
     # Search for textures urls
     if 'textures' in rootNode:

--- a/tangram_bundler/__init__.py
+++ b/tangram_bundler/__init__.py
@@ -1,97 +1,234 @@
 #!/usr/bin/env python
 
 import os, sys, glob, yaml, zipfile
+from urlparse import urljoin
 
 # Append uniform textures
 # - uniforms could reference a texture already loaded from textures: {} or could explicitly define a texture file
-def addUniformTextureDependency(file_list, basePath, yaml_file, styleName, uniformName):
+def addUniformTextureDependency(file_list, basePath, rootNode, styleName, uniformName):
     referenceTexturePath = ""
     explicitUniformTexturePath = ""
-    key = yaml_file['styles'][styleName]['shaders']['uniforms'][uniformName]
+    key = rootNode['styles'][styleName]['shaders']['uniforms'][uniformName]
 
     if isinstance(key, basestring):
-        if ('textures' in yaml_file) and (key in yaml_file['textures']):
-            referenceTexturePath = basePath + '/' + yaml_file['textures'][ yaml_file['styles'][styleName]['shaders']['uniforms'][uniformName] ]['url']
-        explicitUniformTexturePath = basePath + '/' + yaml_file['styles'][styleName]['shaders']['uniforms'][uniformName]
+        if ('textures' in rootNode) and (key in rootNode['textures']):
+            referenceTexturePath = os.path.relpath(rootNode['textures'][ rootNode['styles'][styleName]['shaders']['uniforms'][uniformName] ]['url'], basePath)
+        explicitUniformTexturePath = os.path.relpath(rootNode['styles'][styleName]['shaders']['uniforms'][uniformName], basePath)
 
     if (os.path.exists(explicitUniformTexturePath)):
-        file_list.append(os.path.normpath(explicitUniformTexturePath))
+        file_list.append(explicitUniformTexturePath)
     elif (os.path.exists(referenceTexturePath)):
-        file_list.append(os.path.normpath(referenceTexturePath))
+        file_list.append(referenceTexturePath)
 
 
-# Append yaml dependences in yaml_file ('import' files) to another yaml file (full_yaml_file)
-def addDependencies(file_list, filename):
-    print "Adding dependencies for file: ", filename
-    file_list.append(os.path.normpath(filename))
-    folder = os.path.dirname(filename)
-    yaml_file = yaml.safe_load(open(filename))
-
-    # TODO:
-    #   - Check if any url actually exist and is local before doing nothing
-
+# Append yaml dependences in rootNode ('import' files) to another yaml file (full_rootNode)
+def addDependencies(file_list, rootNode, basePath):
     # Search for fonts urls
-    if 'fonts' in yaml_file:
-        for font in yaml_file['fonts']:
-            # initial Tangram font support
-            if 'url' in yaml_file['fonts'][font]:
-                file_list.append(os.path.normpath(folder + '/' + yaml_file['fonts'][font]['url']))
-
-            # newer Tangram font support
-            for weight in yaml_file['fonts'][font]:
-                if 'url' in weight:
-                    file_list.append(os.path.normpath(folder + '/' + weight['url']))
+    if 'fonts' in rootNode:
+        fontsNode = rootNode['fonts']
+        for font in fontsNode:
+            fontNode = fontsNode[font]
+            for prop in fontNode:
+                # initial Tangram font support
+                if 'url' in prop:
+                    file_list.append(os.path.relpath(prop['url'], basePath))
+                # newer Tangram font support
+                if 'weight' in prop and type(prop['weight']) is str:
+                    file_list.append(os.path.relpath(prop['weight'], basePath))
 
     # Search for textures urls
-    if 'textures' in yaml_file:
-        for texture in yaml_file['textures']:
-            if 'url' in yaml_file['textures'][texture]:
-                file_list.append(os.path.normpath(folder + '/' + yaml_file['textures'][texture]['url']))
+    if 'textures' in rootNode:
+        texturesNode = rootNode['textures']
+        for texture in texturesNode:
+            textureNode = texturesNode[texture]
+            if 'url' in textureNode:
+                file_list.append(os.path.relpath(textureNode['url'], basePath))
 
-    # Search for u_envmap or u_ramp urls
-    if 'styles' in yaml_file:
-        for style in yaml_file['styles']:
-            if 'shaders' in yaml_file['styles'][style]:
-                if 'uniforms' in yaml_file['styles'][style]['shaders']:
-                    for uniform in yaml_file['styles'][style]['shaders']['uniforms']:
-                        addUniformTextureDependency(file_list, folder, yaml_file, style, uniform)
+    # Search for asset url in styles
+    if 'styles' in rootNode:
+        stylesNode = rootNode['styles']
+        for style in stylesNode:
+            styleNode = stylesNode[style]
+            if 'shaders' in styleNode:
+                shadersNode = styleNode['shaders']
+                if 'uniforms' in shadersNode:
+                    uniformsNode = shadersNode['uniforms']
+                    for uniform in uniformsNode:
+                        addUniformTextureDependency(file_list, basePath, rootNode, style, uniform)
+            if 'texture' in styleNode:
+                file_list.append(os.path.relpath(styleNode['texture'], basePath))
+            if 'material' in styleNode:
+                materialNode = styleNode['material']
+                if (type(materialNode) is dict):
+                    for prop in ['emission', 'ambient', 'diffuse', 'specular', 'normal']:
+                        propNode = materialNode[prop]
+                        if (type(propNode) is dict and 'texture' in propNode):
+                            file_list.append(os.path.relpath(propNode['texture'], basePath))
 
-    # Search for inner dependencies
+
+def ignoreFileForBundling(fileName):
+    # we atleast know we need to ignore bundling any network url (todo: fetch yaml http urls and do not ignore these)
+    if (fileName.startswith("http") and not fileName.endswith(".yaml")):
+        return False
+    return True
+
+def collectAllImports(all_imports):
+    if (len(all_imports) <= 0):
+        return
+    
+    subImports = {}
+    for fileName in all_imports:
+        yaml_file = all_imports[fileName]
+        directory = os.path.dirname(fileName)
+        if 'import' in yaml_file:
+            importNode = yaml_file['import']
+            if (type(importNode) is str):
+                importPath = os.path.abspath(directory + '/' + importNode)
+                subImports[importPath] = yaml.safe_load(open(importPath)) 
+            else:
+                for imp in importNode:
+                    importPath = os.path.abspath(directory + '/' + imp)
+                    subImports[importPath] = yaml.safe_load(open(importPath))
+            collectAllImports(subImports)
+    all_imports.update(subImports)
+
+def getSceneImports(filename):
+    imports = []
+    directory = os.path.dirname(filename)
+    yaml_file = yaml.safe_load(open(filename))
     if 'import' in yaml_file:
-        if (type(yaml_file['import']) is str):
-            addDependencies(file_list, folder + '/' + yaml_file['import'])
+        importNode = yaml_file['import']
+        if (type(importNode) is str):
+            importPath = directory + '/' + importNode
+            imports.append(importPath)
         else:
-            for file in yaml_file['import']:
-                addDependencies(file_list, folder + '/' + file)
+            for imp in importNode:
+                importPath = directory + '/' + imp
+                imports.append(importPath)
+    return imports
+
+def mergeMapFields(yamlRoot, sceneNode):
+    for key in sceneNode:
+        source = sceneNode[key]
+        if key not in yamlRoot:
+            yamlRoot[key] = source
+            continue
+        if ((yamlRoot[key] is None) or (type(yamlRoot[key]) is not dict)):
+            yamlRoot[key] = source
+        else: #(type(yamlRoot[key]) is dict):
+            if (type(source) is dict):
+                mergeMapFields(yamlRoot[key], source)
+            else:
+                yamlRoot[key] = source
+
+def resolveGenericPath(input, basePath):
+    if (type(input) is str):
+        return urljoin(basePath, input)
+    else:
+        return input
+
+def resolveSceneTextureUrls(texturesNode, basePath):
+    for texture in texturesNode:
+        textureNode = texturesNode[texture]
+        if 'url' in textureNode:
+            textureNode['url'] = resolveGenericPath(textureNode['url'], basePath)
+
+def resolveMaterialTextureUrls(materialNode, basePath):
+    if (type(materialNode) is dict):
+        for prop in ['emission', 'ambient', 'diffuse', 'specular', 'normal']:
+            propNode = materialNode[prop]
+            if (type(materialNode[prop]) is dict and 'texture' in materialNode[prop]):
+                materialNode[prop]['texture'] = resolveGenericPath(materialNode[prop]['texture'], basePath)
+
+def resolveShaderTextureUrls(shadersNode, basePath):
+    if (type(shadersNode) is dict):
+        if 'uniforms' in shadersNode:
+            for uniform in shadersNode['uniforms']:
+                if (type(shadersNode['uniforms'][uniform]) is str):
+                    shadersNode['uniforms'][uniform] = resolveGenericPath(shadersNode['uniforms'][uniform], basePath)
+                elif (type(shadersNode['uniforms'][uniform]) is list):
+                    for uni in shadersNode['uniforms'][uniform]:
+                        if type(uni) is str:
+                            uni = resolveGenericPath(shadersNode['uniforms'][uniform][uni], basePath)
+
+def resolveSceneStyleUrls(stylesNode, basePath):
+    for style in stylesNode:
+        if (type(stylesNode[style]) is not dict):
+            continue
+        if 'texture' in stylesNode[style]:
+            stylesNode[style]['texture'] = resolveGenericPath(stylesNode[style]['texture'], basePath)
+        if 'material' in stylesNode[style]:
+            resolveMaterialTextureUrls(stylesNode[style]['materials'], basePath)
+        if 'shaders' in stylesNode[style]:
+            resolveShaderTextureUrls(stylesNode[style]['shaders'], basePath)
+
+def resolveSceneFontsUrl(fontsNode, basePath):
+    if (type(fontsNode) is dict):
+        for font in fontsNode:
+            fontNode = fontsNode[font]
+            if (type(fontNode) is dict and 'url' in fontNode):
+                fontNode['url'] = resolveGenericPath(fontNode['url'], basePath)
+            elif(type(fontNode) is list):
+                for f in fontNode:
+                    if 'url' in f:
+                        f['url'] = resolveGenericPath(f['url'], basePath)
+
+def resolveSceneUrls(yamlRoot, filename):
+    basePath = filename
+    if 'textures' in yamlRoot:
+        resolveSceneTextureUrls(yamlRoot['textures'], basePath)
+    if 'styles' in yamlRoot:
+        resolveSceneStyleUrls(yamlRoot['styles'], basePath)
+    if 'fonts' in yamlRoot:
+        resolveSceneFontsUrl(yamlRoot['fonts'], basePath)
+
+
+def importSceneRecursive(yamlRoot, filename, all_imports, importedScenes):
+    if filename in importedScenes:
+        return
+    importedScenes.add(filename)
+    sceneNode = all_imports[filename]
+    if ((sceneNode is None) or (type(sceneNode) is not dict)):
+        return
+    imports = getSceneImports(filename)
+    sceneNode['import'] = None
+    for importScene in imports:
+        importSceneRecursive(yamlRoot, importScene, all_imports, importedScenes)
+    importedScenes.remove(filename)
+    print "merging scene file to root: ", filename
+    mergeMapFields(yamlRoot, sceneNode)
+    resolveSceneUrls(yamlRoot, filename)
 
 # ================================== Main functions
 def bundler(full_filename):
     print full_filename, os.getcwd()
     filename, file_extension = os.path.splitext(full_filename)
     if file_extension == '.yaml':
+
+        all_imports = {}
+        absFilename = os.path.abspath(full_filename)
+        all_imports[absFilename]= yaml.safe_load(open(absFilename))
+        collectAllImports(all_imports)
+        
+        rootNode = {}
+        importedScenes = set()
+        importSceneRecursive(rootNode, absFilename, all_imports, importedScenes)
+
         all_dependencies = []
+        basePath = os.path.dirname(absFilename)
+        addDependencies(all_dependencies, rootNode, basePath)
 
-        # 1st order dependencies
-        addDependencies(all_dependencies, './'+full_filename)
-
-        # 2nd order theme dependencies
-        try:
-            for file in os.listdir(os.getcwd() + "/themes"):
-                if file.endswith(".yaml"):
-                    # track like normal
-                    all_dependencies.append("themes/" + file)
-                    # some themes require additional assets
-                    print "looking at dependencies for: %s" % (file,)
-                    addDependencies(all_dependencies, "themes/" + file)
-        except Exception:
-            print "\tskipping: themes (none found)"
+        for file in all_imports:
+            all_dependencies.append(os.path.relpath(file, basePath))
 
         files = list(set(all_dependencies))
+        print files
 
         print "Bundling ",filename,"width",len(files),"dependencies, into ",filename+".zip"
         zipf = zipfile.ZipFile(filename+'.zip', 'w', zipfile.ZIP_DEFLATED)
         for file in files:
-            zipf.write(file)
+            if (ignoreFileForBundling(file) and os.path.exists(file)):
+                zipf.write(file)
         zipf.close()
     else:
         print 'Error: file',

--- a/tangram_bundler/__init__.py
+++ b/tangram_bundler/__init__.py
@@ -11,7 +11,7 @@ LAYER_KEY_WORDS = ['data', 'filter', 'visible', 'enabled']
 WARN_COLOR = '\033[93m'
 NORM_COLOR = '\033[0m'
 
-def getUniformTexturePath(fileList, basePath, rootNode, uniformTextureStr):
+def appendUniformTexturePath(fileList, basePath, rootNode, uniformTextureStr):
     referenceTexturePath = ""
     explicitUniformTexturePath = ""
     if ('textures' in rootNode) and (uniformTextureStr in rootNode['textures']):
@@ -20,27 +20,26 @@ def getUniformTexturePath(fileList, basePath, rootNode, uniformTextureStr):
     explicitUniformTexturePath = os.path.relpath(uniformTextureStr, basePath)
 
     if (os.path.exists(explicitUniformTexturePath)):
+        fileList.append(explicitUniformTexturePath)
         return explicitUniformTexturePath
     elif (os.path.exists(referenceTexturePath)):
-        return referenceTexturePath
+        fileList.append(referenceTexturePath)
     return None
 
 def addUniformTextureDependency(fileList, basePath, rootNode, styleName, uniformName):
     key = rootNode['styles'][styleName]['shaders']['uniforms'][uniformName]
 
     if isinstance(key, basestring):
-        uniformTexture = getUniformTexturePath(fileList, basePath, rootNode, key)
+        uniformTexture = appendUniformTexturePath(fileList, basePath, rootNode, key)
         if uniformTexture:
             rootNode['styles'][styleName]['shaders']['uniforms'][uniformName] = uniformTexture
-            fileList.append(uniformTexture)
     elif isinstance(key, list):
         index = 0
         for textureStr in key:
             if isinstance(textureStr, basestring):
-                uniformTexture = getUniformTexturePath(fileList, basePath, rootNode, textureStr)
+                uniformTexture = appendUniformTexturePath(fileList, basePath, rootNode, textureStr)
                 if uniformTexture:
                     rootNode['styles'][styleName]['shaders']['uniforms'][uniformName][index] = uniformTexture
-                    fileList.append(uniformTexture)
 
 def appendDrawRuleTexture(fileList, drawRule, basePath):
     if 'texture' in drawRule:

--- a/tangram_bundler/__init__.py
+++ b/tangram_bundler/__init__.py
@@ -198,6 +198,10 @@ def resolveSceneStyleUrls(stylesNode, basePath):
             resolveMaterialTextureUrls(stylesNode[style]['materials'], basePath)
         if 'shaders' in stylesNode[style]:
             resolveShaderTextureUrls(stylesNode[style]['shaders'], basePath)
+        if 'draw' in stylesNode[style]:
+            drawNode = stylesNode[style]['draw']
+            if 'texture' in drawNode:
+                stylesNode[style]['draw]']['texture'] = resolveGenericPath(stylesNode[style]['draw]']['texture'], basePath)
 
 def resolveSceneFontsUrl(fontsNode, basePath):
     if (type(fontsNode) is dict):
@@ -210,6 +214,22 @@ def resolveSceneFontsUrl(fontsNode, basePath):
                     if 'url' in f:
                         f['url'] = resolveGenericPath(f['url'], basePath)
 
+def resolveLayersDrawTexture(layerNode, basePath):
+    for key in layerNode:
+        if key == 'data' or key == 'filter' or key == 'visible' or key == 'enabled':
+            # ignore these layer keys
+            continue
+        elif key == 'draw':
+            drawNode = layerNode['draw']
+            for drawRule in drawNode:
+                drawRuleNode = drawNode[drawRule]
+                if 'texture' in drawRuleNode:
+                    drawRuleNode['texture'] = resolveGenericPath(drawRuleNode['texture'], basePath)
+        else:
+            subLayerNode = layerNode[key]
+            resolveLayersDrawTexture(subLayerNode, basePath)
+
+
 def resolveSceneUrls(yamlRoot, filename):
     basePath = filename
     if 'textures' in yamlRoot:
@@ -218,6 +238,10 @@ def resolveSceneUrls(yamlRoot, filename):
         resolveSceneStyleUrls(yamlRoot['styles'], basePath)
     if 'fonts' in yamlRoot:
         resolveSceneFontsUrl(yamlRoot['fonts'], basePath)
+    if 'layers' in yamlRoot:
+        layersNode = yamlRoot['layers']
+        for layerNode in layersNode:
+            resolveLayersDrawTexture(yamlRoot['layers'][layerNode], basePath)
 
 
 def importSceneRecursive(yamlRoot, filename, allImports, importedScenes):

--- a/tangram_bundler/__init__.py
+++ b/tangram_bundler/__init__.py
@@ -6,6 +6,8 @@ from urlparse import urljoin
 # Append uniform textures
 # - uniforms could reference a texture already loaded from textures: {} or could explicitly define a texture file
 
+LAYER_KEY_WORDS = ['data', 'filter', 'visible', 'enabled']
+
 def appendUniformTexturePath(fileList, basePath, rootNode, uniformTextureStr):
     referenceTexturePath = ""
     explicitUniformTexturePath = ""
@@ -34,7 +36,7 @@ def appendDrawRuleTexture(fileList, drawRule, basePath):
 
 def appendLayerDrawRuleTextures(fileList, layerNode, basePath):
     for key in layerNode:
-        if key == 'data' or key == 'filter' or key == 'visible' or key == 'enabled':
+        if key in LAYER_KEY_WORDS:
             # ignore these layer keys
             continue
         elif key == 'draw':
@@ -216,7 +218,7 @@ def resolveSceneFontsUrl(fontsNode, basePath):
 
 def resolveLayersDrawTexture(layerNode, basePath):
     for key in layerNode:
-        if key == 'data' or key == 'filter' or key == 'visible' or key == 'enabled':
+        if key in LAYER_KEY_WORDS:
             # ignore these layer keys
             continue
         elif key == 'draw':

--- a/tangram_bundler/__init__.py
+++ b/tangram_bundler/__init__.py
@@ -8,6 +8,9 @@ from urlparse import urljoin
 
 LAYER_KEY_WORDS = ['data', 'filter', 'visible', 'enabled']
 
+WARN_COLOR = '\033[93m'
+NORM_COLOR = '\033[0m'
+
 def getUniformTexturePath(fileList, basePath, rootNode, uniformTextureStr):
     referenceTexturePath = ""
     explicitUniformTexturePath = ""
@@ -50,8 +53,11 @@ def appendLayerDrawRuleTextures(fileList, layerNode, basePath):
             continue
         elif key == 'draw':
             drawNode = layerNode['draw']
-            for drawRules in drawNode:
-                appendDrawRuleTexture(fileList, drawNode[drawRules], basePath)
+            if type(drawNode) is list:
+                for drawRules in drawNode:
+                    appendDrawRuleTexture(fileList, drawNode[drawRules], basePath)
+            elif type(drawNode) is dict:
+                appendDrawRuleTexture(fileList, drawNode, basePath)
         else:
             subLayerNode = layerNode[key]
             appendLayerDrawRuleTextures(fileList, subLayerNode, basePath)
@@ -241,10 +247,16 @@ def resolveLayersDrawTexture(layerNode, basePath):
             continue
         elif key == 'draw':
             drawNode = layerNode['draw']
-            for drawRule in drawNode:
-                drawRuleNode = drawNode[drawRule]
-                if 'texture' in drawRuleNode:
-                    drawRuleNode['texture'] = resolveGenericPath(drawRuleNode['texture'], basePath)
+            if type(drawNode) is list:
+                for drawRule in drawNode:
+                    drawRuleNode = drawNode[drawRule]
+                    if 'texture' in drawRuleNode:
+                        drawRuleNode['texture'] = resolveGenericPath(drawRuleNode['texture'], basePath)
+            elif type(drawNode) is dict:
+                if 'texture' in drawNode:
+                    drawNode['texture'] = resolveGenericPath(drawNode['texture'], basePath)
+            else:
+                print WARN_COLOR + "Draw Rule is none for key ", key, " in layer ", str(layerNode) + NORM_COLOR
         else:
             subLayerNode = layerNode[key]
             resolveLayersDrawTexture(subLayerNode, basePath)

--- a/tangram_bundler/__init__.py
+++ b/tangram_bundler/__init__.py
@@ -301,15 +301,17 @@ def bundler(filename, unifiedYaml, exportAsJson):
 
     if unifiedYaml:
         if exportAsJson:
-            unifiedBundledSceneJsonPath = os.path.abspath(urljoin(absFilename, "./unifiedBundledScene.json"))
-            with open(unifiedBundledSceneJsonPath, 'w') as outfile:
+            unifiedJsonFilename = os.path.splitext(filename)[0] + '.json'
+            with open(unifiedJsonFilename, 'w') as outfile:
                 json.dump(rootNode, outfile)
-            allDependencies.append(os.path.relpath(unifiedBundledSceneJsonPath, basePath))
+            allDependencies.append(os.path.relpath(unifiedJsonFilename, basePath))
         else:
-            unifiedBundledSceneYamlPath = os.path.abspath(urljoin(absFilename, "./unifiedBundledScene.yaml"))
-            with open(unifiedBundledSceneYamlPath, 'w') as outfile:
+            backupFilename = filename + ".bck"
+            os.rename(filename, backupFilename)
+            unifiedYamlFilename = filename
+            with open(unifiedYamlFilename, 'w') as outfile:
                 yaml.dump(rootNode, outfile, default_flow_style=False)
-            allDependencies.append(os.path.relpath(unifiedBundledSceneYamlPath, basePath))
+            allDependencies.append(os.path.relpath(unifiedYamlFilename, basePath))
     else:
         for file in allImports:
             allDependencies.append(os.path.relpath(file, basePath))
@@ -324,14 +326,16 @@ def bundler(filename, unifiedYaml, exportAsJson):
             zipf.write(file)
     zipf.close()
 
-    # delete unified file post bundling
     if unifiedYaml:
         if exportAsJson:
-            unifiedBundledSceneJsonPath = os.path.abspath(urljoin(absFilename, "./unifiedBundledScene.json"))
-            os.remove(unifiedBundledSceneJsonPath)
+            #remove temp json file, already bundled in zip archive
+            unifiedJsonFilename = os.path.splitext(filename)[0] + '.json'
+            os.remove(unifiedJsonFilename)
         else:
-            unifiedBundledSceneYamlPath = os.path.abspath(urljoin(absFilename, "./unifiedBundledScene.yaml"))
-            os.remove(unifiedBundledSceneYamlPath)
+            #rename original demo file back!, modified unified one already bundled in zip archive
+            backupFilename = filename + ".bck"
+            os.rename(backupFilename, filename)
+    
 
 def main():
 

--- a/tangram_bundler/__init__.py
+++ b/tangram_bundler/__init__.py
@@ -193,7 +193,8 @@ def importSceneRecursive(yamlRoot, filename, allImports, importedScenes):
     imports = getSceneImports(filename)
     sceneNode['import'] = None
     for importScene in imports:
-        importSceneRecursive(yamlRoot, importScene, allImports, importedScenes)
+        importFilename = os.path.abspath(urljoin(filename, importScene))
+        importSceneRecursive(yamlRoot, importFilename, allImports, importedScenes)
     importedScenes.remove(filename)
     print "merging scene file to root: ", filename
     mergeMapFields(yamlRoot, sceneNode)
@@ -208,7 +209,7 @@ def bundler(filename):
     absFilename = os.path.abspath(filename)
     allImports[absFilename] = loadYaml(absFilename)
     collectAllImports(allImports)
-    
+
     rootNode = {}
     importedScenes = set()
     importSceneRecursive(rootNode, absFilename, allImports, importedScenes)

--- a/tangram_bundler/__init__.py
+++ b/tangram_bundler/__init__.py
@@ -72,6 +72,11 @@ def fetchDependencies(fileList, rootNode, basePath):
                         propNode = materialNode[prop]
                         if (type(propNode) is dict and 'texture' in propNode):
                             fileList.append(os.path.relpath(propNode['texture'], basePath))
+            if 'draw' in styleNode:
+                drawNode = styleNode['draw']
+                for drawRule in drawNode:
+                    if 'texture' in drawRule:
+                        fileList.append(os.path.relpath(drawRule['texture'], basePath))
 
 def validFileToBundle(fileName):
     # we atleast know we need to ignore bundling any network url (todo: fetch yaml http urls and do not ignore these)

--- a/tangram_bundler/__init__.py
+++ b/tangram_bundler/__init__.py
@@ -203,6 +203,7 @@ def importSceneRecursive(yamlRoot, filename, allImports, importedScenes):
 def bundler(filename):
     print filename, os.getcwd()
 
+    zipFilename = os.path.splitext(filename)[0] + '.zip'
     allImports = {}
     absFilename = os.path.abspath(filename)
     allImports[absFilename] = loadYaml(absFilename)
@@ -222,8 +223,8 @@ def bundler(filename):
     files = list(set(allDependencies))
     print files
 
-    print "Bundling ",filename,"width",len(files),"dependencies, into ",filename+".zip"
-    zipf = zipfile.ZipFile(filename+'.zip', 'w', zipfile.ZIP_DEFLATED)
+    print "Bundling ",filename,"width",len(files),"dependencies, into ",zipFilename
+    zipf = zipfile.ZipFile(zipFilename, 'w', zipfile.ZIP_DEFLATED)
     for file in files:
         if (validFileToBundle(file) and os.path.exists(file)):
             zipf.write(file)

--- a/tangram_bundler/__init__.py
+++ b/tangram_bundler/__init__.py
@@ -15,7 +15,8 @@ def getUniformTexturePath(fileList, basePath, rootNode, uniformTextureStr):
     referenceTexturePath = ""
     explicitUniformTexturePath = ""
     if ('textures' in rootNode) and (uniformTextureStr in rootNode['textures']):
-        referenceTexturePath = os.path.relpath(rootNode['textures'][ uniformTextureStr]['url'], basePath)
+        if 'url' in rootNode['textures'][ uniformTextureStr]:
+            referenceTexturePath = os.path.relpath(rootNode['textures'][ uniformTextureStr]['url'], basePath)
     explicitUniformTexturePath = os.path.relpath(uniformTextureStr, basePath)
 
     if (os.path.exists(explicitUniformTexturePath)):
@@ -60,7 +61,8 @@ def appendLayerDrawRuleTextures(fileList, layerNode, basePath):
                 appendDrawRuleTexture(fileList, drawNode, basePath)
         else:
             subLayerNode = layerNode[key]
-            appendLayerDrawRuleTextures(fileList, subLayerNode, basePath)
+            if type(subLayerNode) is dict:
+                appendLayerDrawRuleTextures(fileList, subLayerNode, basePath)
 
 # Fetch all asset dependencies in the constructed rootNode
 def fetchDependencies(fileList, rootNode, basePath):
@@ -259,7 +261,8 @@ def resolveLayersDrawTexture(layerNode, basePath):
                 print WARN_COLOR + "Draw Rule is none for key ", key, " in layer ", str(layerNode) + NORM_COLOR
         else:
             subLayerNode = layerNode[key]
-            resolveLayersDrawTexture(subLayerNode, basePath)
+            if type(subLayerNode) is dict:
+                resolveLayersDrawTexture(subLayerNode, basePath)
 
 
 def resolveSceneUrls(yamlRoot, filename):

--- a/tangram_bundler/__init__.py
+++ b/tangram_bundler/__init__.py
@@ -304,6 +304,7 @@ def bundler(filename, unifiedYaml, exportAsJson):
             unifiedBundledSceneJsonPath = os.path.abspath(urljoin(absFilename, "./unifiedBundledScene.json"))
             with open(unifiedBundledSceneJsonPath, 'w') as outfile:
                 json.dump(rootNode, outfile)
+            allDependencies.append(os.path.relpath(unifiedBundledSceneJsonPath, basePath))
         else:
             unifiedBundledSceneYamlPath = os.path.abspath(urljoin(absFilename, "./unifiedBundledScene.yaml"))
             with open(unifiedBundledSceneYamlPath, 'w') as outfile:


### PR DESCRIPTION
The import process for bundler is less hacky and looks very similar to how JS and ES does scene importing.
- bundler now does a dfs traversal of the scene imports
    - overrides apt yaml nodes with absolute path from the associated
    imported scene
- once a unified node representing all the imports is created
    - it goes and collects valid assets to be imported
- the list of valid assets is appended with urls of all the imported yaml files
- with this list of files handy, creates the zip archive
- Adds ability to export a unified scene where all yaml importing and node merging is already done.
  - adds an option to export a json file instead of yaml when doing unified bundling.